### PR TITLE
Fix Netlify config parsing error by removing duplicate section

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -6,9 +6,6 @@
 [build.environment]
   NODE_VERSION = "18.19.0"
   NPM_VERSION = "9.6.0"
-
-# Essential environment variables (set these in Netlify UI)
-[build.environment]
   NODE_ENV = "production"
 
 # API routes as Netlify functions


### PR DESCRIPTION
## Purpose

Fix Netlify deployment failure caused by a configuration parsing error. The build was failing at line 9 with "Failed to parse configuration" due to a syntax error in the `netlify.toml` file that prevented proper deployment.

## Code changes

- Removed duplicate `[build.environment]` section in `netlify.toml`
- Consolidated environment variables under a single `[build.environment]` block
- Moved `NODE_ENV = "production"` to the existing environment section
- Eliminated the configuration syntax error that was causing the Netlify build to fail

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 6`

🔗 [Edit in Builder.io](https://builder.io/app/projects/794c9cfffa1345f398bbb8653c2506e5/quantum-landing)

👀 [Preview Link](https://794c9cfffa1345f398bbb8653c2506e5-quantum-landing.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>794c9cfffa1345f398bbb8653c2506e5</projectId>-->
<!--<branchName>quantum-landing</branchName>-->